### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": ">=7.1.0"
     },
     "require-dev": {
-        "schnittstabil/phpunit-starter": "^6.0 || ^7.0"
+        "schnittstabil/phpunit-starter": "^7.0"
     },
     "extra": {
         "schnittstabil/sugared-phpunit": {

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -19,8 +19,8 @@ class EnvTest extends \PHPUnit\Framework\TestCase
     public function testEnvShouldReturnNonTypedDefaultValues()
     {
         putenv('baz');
-        $this->assertSame(env('baz'), null);
-        $this->assertSame(env('baz', null), null);
+        $this->assertNull(env('baz'));
+        $this->assertNull(env('baz', null));
         $this->assertSame(env('baz', 42), 42);
         $this->assertSame(env('baz', '42'), '42');
 

--- a/tests/TypedTest.php
+++ b/tests/TypedTest.php
@@ -13,41 +13,40 @@ use Schnittstabil\Get;
  */
 class TypedTest extends \PHPUnit\Framework\TestCase
 {
-    public function testTypedShouldReturnStringValues()
+    public function typedShouldReturnStringValuesProvider()
     {
-        $this->assertSame(typed('unicorn'), 'unicorn');
+        return [
+            ['unicorn', 'unicorn'],
+            ['"true"', 'true'],
+            ["'true'", 'true'],
+            ['"false"', 'false'],
+            ["'false'", 'false'],
+            ['"yes"', 'yes'],
+            ["'yes'", 'yes'],
+            ['"no"', 'no'],
+            ["'no'", 'no'],
+            ['"on"', 'on'],
+            ["'on'", 'on'],
+            ['"off"', 'off'],
+            ["'off'", 'off'],
+            ['"0"', '0'],
+            ["'0'", '0'],
+            ['"1"', '1'],
+            ["'1'", '1'],
+            ['"0.0"', '0.0'],
+            ["'0.0'", '0.0'],
+            ['"1.0"', '1.0'],
+            ["'1.0'", '1.0'],
+            ['', ''],
+        ];
+    }
 
-        $this->assertSame(typed('"true"'), 'true');
-        $this->assertSame(typed("'true'"), 'true');
-
-        $this->assertSame(typed('"false"'), 'false');
-        $this->assertSame(typed("'false'"), 'false');
-
-        $this->assertSame(typed('"yes"'), 'yes');
-        $this->assertSame(typed("'yes'"), 'yes');
-
-        $this->assertSame(typed('"no"'), 'no');
-        $this->assertSame(typed("'no'"), 'no');
-
-        $this->assertSame(typed('"on"'), 'on');
-        $this->assertSame(typed("'on'"), 'on');
-
-        $this->assertSame(typed('"off"'), 'off');
-        $this->assertSame(typed("'off'"), 'off');
-
-        $this->assertSame(typed('"0"'), '0');
-        $this->assertSame(typed("'0'"), '0');
-
-        $this->assertSame(typed('"1"'), '1');
-        $this->assertSame(typed("'1'"), '1');
-
-        $this->assertSame(typed('"0.0"'), '0.0');
-        $this->assertSame(typed("'0.0'"), '0.0');
-
-        $this->assertSame(typed('"1.0"'), '1.0');
-        $this->assertSame(typed("'1.0'"), '1.0');
-
-        $this->assertSame(typed(''), '');
+    /**
+     * @dataProvider typedShouldReturnStringValuesProvider
+     */
+    public function testTypedShouldReturnStringValues($string, $resultString)
+    {
+        $this->assertSame(typed($string), $resultString);
     }
 
     public function testTypedShouldReturnIntValues()
@@ -66,32 +65,32 @@ class TypedTest extends \PHPUnit\Framework\TestCase
 
     public function testTypedShouldReturnBoolValues()
     {
-        $this->assertSame(typed('true'), true);
-        $this->assertSame(typed('on'), true);
-        $this->assertSame(typed('yes'), true);
+        $this->assertTrue(typed('true'));
+        $this->assertTrue(typed('on'));
+        $this->assertTrue(typed('yes'));
 
-        $this->assertSame(typed('false'), false);
-        $this->assertSame(typed('off'), false);
-        $this->assertSame(typed('no'), false);
+        $this->assertFalse(typed('false'));
+        $this->assertFalse(typed('off'));
+        $this->assertFalse(typed('no'));
     }
 
     public function testTypedShouldReturnNullValues()
     {
-        $this->assertSame(typed(null), null);
-        $this->assertSame(typed('null'), null);
+        $this->assertNull(typed(null));
+        $this->assertNull(typed('null'));
     }
 
     public function testApiTypedExample()
     {
         $this->assertEquals(Get\typed('42'), 42);
 
-        $this->assertEquals(Get\typed('true'), true);
-        $this->assertEquals(Get\typed('yes'), true);
-        $this->assertEquals(Get\typed('on'), true);
+        $this->assertTrue(Get\typed('true'));
+        $this->assertTrue(Get\typed('yes'));
+        $this->assertTrue(Get\typed('on'));
 
-        $this->assertEquals(Get\typed('false'), false);
-        $this->assertEquals(Get\typed('no'), false);
-        $this->assertEquals(Get\typed('off'), false);
+        $this->assertFalse(Get\typed('false'));
+        $this->assertFalse(Get\typed('no'));
+        $this->assertFalse(Get\typed('off'));
 
         // escaping
         $this->assertEquals(Get\typed('"true"'), 'true');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,10 +3,3 @@
 namespace Schnittstabil\Get;
 
 require __DIR__.'/../vendor/autoload.php';
-
-/*
- * PHPUnit 5/6
- */
-if (!class_exists(\PHPUnit\Framework\TestCase::class)) {
-    class_alias(\PHPUnit_Framework_TestCase::class, \PHPUnit\Framework\TestCase::class);
-}


### PR DESCRIPTION
# Changed log
- Using the proper assertion to assert the result values.
- Using the `DataProvider` to collect the test cases.
- Remove the `class_alias` because the latest PHPUnit version uses the class-based PHPUnit namespace.
- Remove the `schnittstabil/phpunit-starter` `^6.0` version because the `^7.0` version requires `php-7.1` version.